### PR TITLE
chore: cancel concurrent PR workflows but latest one

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: lint-pr-title-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   lint-pr-title:
     name: Lint PR title


### PR DESCRIPTION
Related to the issue https://github.com/thenativeweb/eventsourcingdb-client-javascript/issues/264